### PR TITLE
Updated domain two domains to correct typo

### DIFF
--- a/squirtdanger/squirtdanger_distribution.csv
+++ b/squirtdanger/squirtdanger_distribution.csv
@@ -12,7 +12,7 @@ First Seen,Distribution Server
 2018-02-15 08:12:13,apps.identrust.com
 2018-02-24 03:11:11,asedownloadgate.com
 2018-02-24 08:12:44,auth.drp.su
-2018-04-12 10:57:31.885903,bush.basinafterthought.bidhttp
+2018-04-12 10:57:31.885903,bush.basinafterthought.bid
 2018-03-25 14:26:49,deccripted.had.su
 2018-02-17 04:10:20,down.rmb2019.me
 2018-02-24 08:12:44,download.drp.su
@@ -26,7 +26,7 @@ First Seen,Distribution Server
 2018-03-02 02:26:47,inerino.ru
 2018-02-25 16:55:17,info4.had.su
 2018-03-15 23:36:02,kirillrotkov.had.su
-2018-04-12 10:57:58.862988,lamp.troublerifle.bidhttp
+2018-04-12 10:57:58.862988,lamp.troublerifle.bid
 2018-02-11 07:51:09,lehrerin.in.ua
 2018-02-15 20:58:33,michalsd.beget.tech
 2018-03-23 07:44:41,n97753oy.beget.tech


### PR DESCRIPTION
It appears that the domain on line 15 and 29 had a typo with the TLD bidhttp, updated to reflect .bid TLD.